### PR TITLE
fixed some math ordering and added support for vector2

### DIFF
--- a/easing.gd
+++ b/easing.gd
@@ -25,7 +25,7 @@
 
 
 # Usage:
-#	
+#
 #	onready var Easing = preload("easing.gd")
 #
 #	func testEasing():
@@ -33,7 +33,7 @@
 #		var endValue = 1.0
 #		var change = 1.0
 #		var duration = 1.0
-#	
+#
 #		print(Easing.Cubic.easeOut(0, startValue, change, duration))						# --> 0
 #		print(Easing.Cubic.easeOut(duration / 4.0, startValue, change, duration))			# --> 0.578125
 #		print(Easing.Cubic.easeOut(duration / 2.0, startValue, change, duration))			# --> 0.875
@@ -61,7 +61,7 @@ class Back:
 		return c * (t * t * ((s + 1) * t + s) + 1) + b
 
 	static func easeInOut(t, b, c, d, s = 1.70158):
-		t = t / d / 2
+		t = (t / (d / 2))
 		if (t < 1):
 			s = s * 1.525
 			return c / 2 * (t * t * ((s + 1 ) * t - s)) + b;
@@ -73,6 +73,8 @@ class Back:
 
 class Bounce:
 	static func easeIn(t, b, c, d):
+		if b is Vector2:
+			return c - easeOut(d - t, Vector2.ZERO, c, d) + b
 		return c - easeOut(d - t, 0, c, d) + b
 
 	static func easeOut(t, b, c, d):
@@ -90,6 +92,11 @@ class Bounce:
 			return c * (7.5625 * t * t + 0.984375) + b
 
 	static func easeInOut(t, b, c, d):
+		if b is Vector2:
+			if (t < (d / 2)):
+				return easeIn (t * 2, Vector2.ZERO, c, d) * 0.5 + b
+			else:
+				return easeOut (t * 2 - d, Vector2.ZERO, c, d) * 0.5 + c * 0.5 + b
 		if (t < (d / 2)):
 			return easeIn (t * 2, 0, c, d) * 0.5 + b
 		else:
@@ -106,7 +113,7 @@ class Circ:
 		return c * sqrt(1 - t * t) + b
 
 	static func easeInOut(t, b, c, d):
-		t = t / d / 2
+		t = (t / (d / 2))
 		if (t < 1):
 			return -c / 2 * (sqrt(1 - t * t) - 1) + b
 		else:
@@ -121,10 +128,10 @@ class Cubic:
 
 	static func easeOut(t, b, c, d):
 		t = t / d - 1
-		return c * (t * t * t + 1) + b 
+		return c * (t * t * t + 1) + b
 
 	static func easeInOut(t, b, c, d):
-		t = t / d / 2
+		t = (t / (d / 2))
 		if (t < 1):
 			return c / 2 * t * t * t + b
 		else:
@@ -166,7 +173,7 @@ class Elastic:
 		t = t / d
 		if (t == 1):
 			return b + c
-		var p = d * 0.3
+		var p = d * 0.4
 		var a = c
 		var s = p / 4
 		return (a * pow(2, -10 * t) * sin((t * d - s) * (2 * PI) / p) + c + b)
@@ -188,10 +195,10 @@ class Elastic:
 	static func easeInOut(t, b, c, d):
 		if (t == 0):
 			return b
-		t = t / d / 2
+		t = (t / (d / 2))
 		if (t == 2):
 			return b + c
-		var p = d * (0.3 * 1.5)
+		var p = d * (0.4 * 1.5)
 		var a = c
 		var s = p / 4
 		if (t < 1):
@@ -239,11 +246,12 @@ class Expo:
 			return b
 		if (t == d):
 			return b + c
-		var t = t / d / 2
+		t = (t / (d / 2))
 		if (t < 1):
 			return c / 2 * pow(2, 10 * (t - 1)) + b
 		else:
-			return c / 2 * (-pow(2, -10 * --t) + 2) + b
+			t = t - 1
+			return c / 2 * (-pow(2, -10 * t) + 2) + b
 
 
 class Linear:
@@ -270,11 +278,12 @@ class Quad:
 		return -c * t * (t - 2) + b
 
 	static func easeInOut(t, b, c, d):
-		t = t / d / 2
+		t = (t / (d / 2))
 		if (t < 1):
-			return c / 2 * t * t + b 
+			return c / 2 * t * t + b
 		else:
-			return -c / 2 * ((--t) * (t - 2) - 1) + b
+			t -= 1
+			return -c / 2 * (t * (t - 2) - 1) + b
 
 
 class Quart:
@@ -287,7 +296,7 @@ class Quart:
 		return -c * (t * t * t * t - 1) + b
 
 	static func easeInOut(t, b, c, d):
-		t = t / d / 2
+		t = (t / (d / 2))
 		if (t < 1):
 			return c / 2 * t * t * t * t + b
 		else:
@@ -305,7 +314,7 @@ class Quint:
 		return c * (t * t * t * t * t + 1) + b
 
 	static func easeInOut(t, b, c, d):
-		t = t / d / 2
+		t = (t / (d / 2))
 		if (t < 1):
 			return c / 2 * t * t * t * t * t + b
 		else:


### PR DESCRIPTION
This was just what I was looking for. I did run into some issues using it so I took some time to fork and fix them. I am using Godot 3.1.

I fixed a few of the lines to reorder the math better. the direct compute from lua was not always consistent in gdscript. I also added support for a Vector2 to reduce need to always split the x/y properties.

Let me know if you have questions.
